### PR TITLE
Fix build errors on Ubuntu 17.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 all:
 	g++ -g -c test.cpp -I/usr/local/include -I/usr/local/include/zookeeper
-	g++ -o test test.o -lzookeeper_mt -lmhash
+	g++ -o test test.o -lzookeeper_mt -lmhash -lpthread
 
 clean:
 	rm -rf *.o

--- a/arcus.h
+++ b/arcus.h
@@ -58,7 +58,7 @@ class arcusNode;
 
 // etc
 #include <mhash.h>
-#include "zookeeper.h"
+#include <zookeeper/zookeeper.h>
 
 
 #define MAX_ELEMENT_SIZE	4096


### PR DESCRIPTION
## Issue ##
Ubuntu 17.04에서 apt를 이용하여 zookeeper-mt와 mhash를 설치한 경우 빌드가 실패하는 현상
```
$ make
g++ -g -c test.cpp -I/usr/local/include -I/usr/local/include/zookeeper
In file included from test.cpp:25:0:
arcus.h:61:23: fatal error: zookeeper.h: No such file or directory
 #include "zookeeper.h"
                       ^
compilation terminated.
```
```
$ make
...
g++ -o test test.o -lzookeeper_mt -lmhash
/usr/bin/ld: test.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```